### PR TITLE
Ensure mata is transpiled prior to publishing

### DIFF
--- a/packages/mata/package.json
+++ b/packages/mata/package.json
@@ -6,7 +6,7 @@
   "types": "build/mata.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "npm run build && jest"
   },
   "author": "daniel@danielespeset.com",


### PR DESCRIPTION
I'm not entirely certain what steps lerna takes in publishing, but upon installing mata into a project, there was no `build/` directory. This should fix that.